### PR TITLE
add aria labels to start and end labels

### DIFF
--- a/templates/confidenceSlider.hbs
+++ b/templates/confidenceSlider.hbs
@@ -3,8 +3,8 @@
     <div class="slider-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}} {{/if}} {{/unless}}">
         <div class="slider-holder clearfix">
             <div class="slider-scale-labels">
-                <div class="slider-scale-start">{{labelStart}}</div>
-                <div class="slider-scale-end">{{labelEnd}}</div>
+                <div class="slider-scale-start" aria-label="{{_globals._components._slider.labelStart}}">{{labelStart}}</div>
+                <div class="slider-scale-end" aria-label="{{_globals._components._slider.labelEnd}}">{{labelEnd}}</div>
             </div>
             <div class="slider-scale-numbers clearfix">
                 {{#each _items}}


### PR DESCRIPTION
as per https://github.com/adaptlearning/adapt_framework/issues/2220

Note that I have assumed that it's fine for Confidence Slider to use the same ARIA labels for these as Slider. I can't think of any reason why you'd want them to be different and it will save people from having to set them twice in a project that uses both components. If people feel this is wrong, please say and I will change.