### PR TITLE
Fix: Remove extra space in _marginDir check (fixes #71)

### DIFF
--- a/templates/confidenceSlider.jsx
+++ b/templates/confidenceSlider.jsx
@@ -91,7 +91,7 @@ export default function ConfidenceSlider (props) {
             aria-valuemin={_scaleStart}
             aria-valuemax={_scaleEnd}
             data-rangeslider
-            data-direction={_marginDir === ' right' ?? 'rtl'}
+            data-direction={_marginDir === 'right' ?? 'rtl'}
             disabled={!_isEnabled}
           />
         </div>


### PR DESCRIPTION
Fixes #71 

### Fix
* Removes the extra space in ' right'
