### PR TITLE
Fix: display feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ guide the learner’s interaction with the component.
 
 **\_feedback** (object): If the [**Tutor** extension](https://github.com/adaptlearning/adapt-contrib-tutor) is enabled, these various texts will be displayed depending on the submitted answer. **\_feedback** contains values for three seperate elements: generic, comparison and threshold feedback. Generic feedback is always presented to the user. Comparison feedback is presented on submission if the slider has been linked to another slider. Threshold feedback is determined according to the range in which the user's selection falls. All feedback elements are optional. Each element can be separated by one or more characters (such as a space) or, more commonly, by some HTML markup.
 
+>**title** (string): The text used as the feedback title. Leave empty if no display title is required.
+
+>**altTitle** (string): The text used to provide an alternative heading for Assistive Technology if no display title is required. Only used if `title` is empty.
+
 >**feedbackSeparator** (string): Optional text/markup that will separate each feedback element.
 
 >**generic** (string): Text that will be shown whichever selection is made.

--- a/example.json
+++ b/example.json
@@ -31,6 +31,8 @@
         "_isResetOnRevisit": false,
         "_shouldStoreResponses": true,
         "_feedback": {
+            "title": "Feedback",
+            "altTitle": "",
             "feedbackSeparator": " ",
             "generic": "Thanks for measuring your confidence.",
             "_comparison": {

--- a/js/ConfidenceSliderModel.js
+++ b/js/ConfidenceSliderModel.js
@@ -42,17 +42,25 @@ export default class ConfidenceSliderModel extends SliderModel {
   }
 
   /* override */
-  setupFeedback() {
-    this.set({
-      feedbackTitle: this.get('title'),
-      feedbackMessage: this.getFeedbackString()
-    });
-  }
-
-  /* override */
   updateButtons() {
     if (this.get('_attempts') > 0) return super.updateButtons();
     this.set('_buttonState', this.get('_isEnabled') ? 'submit' : 'reset');
+  }
+
+  /* override */
+  getFeedback(_feedback = this.get('_feedback')) {
+    if (!_feedback) return {};
+    const {
+      altTitle = Adapt.course.get('_globals')._accessibility.altFeedbackTitle || '',
+      title,
+      _classes
+    } = _feedback;
+    return {
+      altTitle,
+      title,
+      _classes,
+      body: this.getFeedbackString()
+    };
   }
 
   getFeedbackString() {

--- a/properties.schema
+++ b/properties.schema
@@ -240,6 +240,26 @@
       "required": true,
       "title": "Feedback",
       "properties": {
+        "title": {
+          "type": "string",
+          "required": false,
+          "default": "",
+          "title": "Title",
+          "inputType": "Text",
+          "validators": [],
+          "help": "The text used as the feedback title. Leave empty if no display title is required.",
+          "translatable": true
+        },
+        "altTitle": {
+          "type": "string",
+          "required": false,
+          "default": "",
+          "title": "Alternative title",
+          "inputType": "Text",
+          "validators": [],
+          "help": "The text used to provide an alternative heading for Assistive Technology if no display title is required. Only used if `title` is empty.",
+          "translatable": true
+        },
         "feedbackSeparator": {
           "type": "string",
           "required": false,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -186,6 +186,24 @@
           "title": "Feedback",
           "default": {},
           "properties": {
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "description": "The text used as the feedback title. Leave empty if no display title is required.",
+              "default": "",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "altTitle": {
+              "type": "string",
+              "title": "Alternative title",
+              "description": "The text used to provide an alternative heading for Assistive Technology if no display title is required. Only used if `title` is empty.",
+              "default": "",
+              "_adapt": {
+                "translatable": true
+              }
+            },
             "feedbackSeparator": {
               "type": "string",
               "title": "Feedback separator",


### PR DESCRIPTION
Fixes #75

### Fix
* Feedback should now be displayed as required
* Added `title` and `altTitle` to schemas and readme. Amended functionality to match other questions as per https://github.com/adaptlearning/adapt-contrib-core/pull/223 - no longer uses component titles if empty.


