### PR TITLE
Update: _buttons ariaLabel amended as per other question components (fixes #81)

### DIFF
--- a/example.json
+++ b/example.json
@@ -59,6 +59,7 @@
                 }
             ]
         },
+        "_comment": "You only need to include _buttons if you want to override the button labels that are set in course.json",
         "_buttons": {
             "_submit": {
                 "buttonText": "Submit",

--- a/example.json
+++ b/example.json
@@ -62,15 +62,15 @@
         "_buttons": {
             "_submit": {
                 "buttonText": "Submit",
-                "ariaLabel": "Submit your answer by clicking here."
+                "ariaLabel": "Select here to submit your answer."
             },
             "_reset": {
                 "buttonText": "Reset",
-                "ariaLabel": "Reset the question by clicking here."
+                "ariaLabel": ""
             },
             "_showFeedback": {
                 "buttonText": "Show feedback",
-                "ariaLabel": "View the question feedback again by clicking here."
+                "ariaLabel": ""
             }
         },
         "_pageLevelProgress": {


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/81

- _example.json_ _buttons ariaLabel amended for consistency with other question components _example.json_. 
- keep label text inclusive, removed reference to 'clicking'.