### PR TITLE
Fix: add scale context to slider start and end labels (fixes #82)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -21,19 +21,23 @@
       "translatable": true
     },
     "labelStart": {
-      "type": "number",
-      "required": true,
-      "default": "1",
-      "inputType": "Number",
+      "type": "string",
+      "required": false,
+      "default": "Start of the scale",
+      "title": "Scale Label - start aria label",
+      "inputType": "Text",
       "validators": [],
+      "help": "Aria label for the start of the slider scale",
       "translatable": true
     },
     "labelEnd": {
-      "type": "number",
-      "required": true,
-      "default": "1",
-      "inputType": "Number",
+      "type": "string",
+      "required": false,
+      "default": "End of the scale",
+      "title": "Scale Label - end aria label",
+      "inputType": "Text",
       "validators": [],
+      "help": "Aria label for the end of the slider scale",
       "translatable": true
     }
   },

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -2,7 +2,7 @@
   "$anchor": "confidenceSlider-component",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "$patch": {
+  "$merge": {
     "source": {
       "$ref": "component"
     },

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -12,17 +12,24 @@
           "type": "object",
           "default": {},
           "properties": {
-            "_confidenceSlider": {
+            "_components": {
               "type": "object",
               "default": {},
               "properties": {
-                "ariaRegion": {
-                  "type": "string",
-                  "title": "Aria region",
-                  "default": "Answer the question by selecting a value from the range. Once you have done so, select the submit button below.",
-                  "properties": {},
-                  "_adapt": {
-                    "translatable": true
+                "_confidenceSlider": {
+                  "type": "object",
+                  "title": "Confidence Slider",
+                  "default": {},
+                  "properties": {
+                    "ariaRegion": {
+                      "type": "string",
+                      "title": "Aria region",
+                      "default": "Answer the question by selecting a value from the range. Once you have done so, select the submit button below.",
+                      "properties": {},
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    }
                   }
                 }
               }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -29,6 +29,22 @@
                       "_adapt": {
                         "translatable": true
                       }
+                    },
+                    "labelStart": {
+                      "type": "string",
+                      "title": "Scale start ARIA label",
+                      "default": "Start of the scale",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "labelEnd": {
+                      "type": "string",
+                      "title": "Scale end ARIA label",
+                      "default": "End of the scale",
+                      "_adapt": {
+                        "translatable": true
+                      }
                     }
                   }
                 }

--- a/templates/confidenceSlider.jsx
+++ b/templates/confidenceSlider.jsx
@@ -100,16 +100,18 @@ export default function ConfidenceSlider (props) {
         <div className="slider__label-container js-slider-label-container">
 
           {labelStart &&
-          <div className="slider__label-start" aria-label={_globals._components._confidenceSlider.labelStart}>
+          <div className="slider__label-start">
             <div className="slider__label-start-inner">
+              <span className="aria-label">{_globals._components._confidenceSlider.labelStart} {_scaleStart}</span>
               {labelStart}
             </div>
           </div>
           }
 
           {labelEnd &&
-          <div className="slider__label-end" aria-label={_globals._components._confidenceSlider.labelEnd}>
+          <div className="slider__label-end">
             <div className="slider__label-end-inner">
+              <span className="aria-label">{_globals._components._confidenceSlider.labelEnd} {_scaleEnd}</span>
               {labelEnd}
             </div>
           </div>


### PR DESCRIPTION
- Remove `aria-label` attribute (this was replacing `labelStart` and `labelEnd` when reading)
- Add `aria-label span` containing scale context (distinguish start or end of scale and scale value). This is read alongside `labelStart` and `labelEnd`.
- Fix schema label error. Global defaults was setting both `labelStart` and `labelEnd` as '1'. Labels updated as per Slider schema for consistency.


How `slider__label-start` should now read:
'Start of the scale, 1, incomplete'

How `slider__label-end` should now read:
'End of the scale, 10, complete'

Issue already addressed in Slider https://github.com/adaptlearning/adapt-contrib-slider/pull/176