### PR TITLE
Fix: ariaScaleName added to give context of scale measurement (fixes #99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ guide the learner’s interaction with the component.
 
 **\_linkedToId** (string): The component ID of a slider to which this slider can be linked. This is optional and if set, will disable user interaction until a selection is submitted on the linked slider.
 
+**ariaScaleName** (string): This will be read out by screen readers when focusing on the scale input (slider handle). An appropriate name should give context to which the scale is a measurement of. The default is `confidence`.
+
 **labelStart** (string): Text/characters that appear at the start of the slider scale.
 
 **labelEnd** (string): Text/characters that appear at the end of the slider scale.

--- a/example.json
+++ b/example.json
@@ -21,6 +21,7 @@
         "_recordInteraction": true,
         "_comment": "ONLY ADD _linkedToId PROPERTY IF THIS SLIDER LINKS TO ANOTHER",
         "_linkedToId": "",
+        "ariaScaleName": "confidence",
         "labelStart": "incomplete",
         "labelEnd": "complete",
         "_scaleStart": 1,

--- a/properties.schema
+++ b/properties.schema
@@ -145,6 +145,14 @@
       "validators": [],
       "help": "The _id of another instance of this component you'd like this instance to be linked to. See the README for more info."
     },
+    "ariaScaleName": {
+      "type": "string",
+      "default": "confidence",
+      "inputType": "Text",
+      "validators": [],
+      "help": "This will be read out by screen readers when focusing on the scale input (slider handle). An appropriate name should give context to which the scale is a measurement of.",
+      "translatable": true
+    },
     "labelStart": {
       "type": "string",
       "required": false,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -100,6 +100,15 @@
           "default": "",
           "properties": {}
         },
+        "ariaScaleName": {
+          "type": "string",
+          "title": "ARIA scale name",
+          "description": "This will be read out by screen readers when focusing on the scale input (slider handle). An appropriate name should give context to which the scale is a measurement of.",
+          "default": "confidence",
+          "_adapt": {
+            "translatable": true
+          }
+        },
         "labelStart": {
           "type": "string",
           "title": "Scale Label - Start",

--- a/templates/confidenceSlider.jsx
+++ b/templates/confidenceSlider.jsx
@@ -14,6 +14,7 @@ export default function ConfidenceSlider (props) {
     body,
     instruction,
     ariaQuestion,
+    ariaScaleName,
     labelStart,
     labelEnd,
     _selectedItem,
@@ -180,6 +181,7 @@ export default function ConfidenceSlider (props) {
           <input className='slider__item-input js-slider-item-input'
             type='range'
             role='slider'
+            aria-label={ariaScaleName}
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/99

This will be read out by screen readers when focusing on the scale input (slider handle). Setting an appropriate `ariaScaleName` will give context to which the scale is a measurement of. Default is 'confidence'.

An accessible name is required for accessibility, see [Mozilla ARIA slider role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role).
 _**An accessible name is required**. If the range's role is applied to an HTML `<input>` element (or `<meter>` or `<progress>` element), the accessible name can come from the associated `<label>`. Otherwise use `aria-labelledby` if a visible label is present or `aria-label` if a visible label is not present._

## Testing PR

In _component.json_, set `ariaScaleName` for the confidenceSlider component:
`"ariaScaleName": "confidence",`

With a screen reader running, focus on the slider input (handle) and "_scale number_, _ariaScaleName_, slider" should be announced.
e.g "1, confidence, slider"