### PR TITLE
Update: remove implied aria properties from <input type="range"> (fixes #105)

### DIFF
--- a/templates/confidenceSlider.jsx
+++ b/templates/confidenceSlider.jsx
@@ -180,15 +180,11 @@ export default function ConfidenceSlider (props) {
 
           <input className='slider__item-input js-slider-item-input'
             type='range'
-            role='slider'
             aria-label={ariaScaleName}
             value={selectedValue}
             min={_scaleStart}
             max={_scaleEnd}
             step={_scaleStep}
-            aria-valuenow={selectedValue}
-            aria-valuemin={_scaleStart}
-            aria-valuemax={_scaleEnd}
             data-direction={_marginDir === 'right' ?? 'rtl'}
             disabled={!_isEnabled}
             onChange={e => onNumberSelected(e.target.value)}


### PR DESCRIPTION
Remove implied properties of <input type="range"> as per [Mozilla ARIA slider role best practice](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role#best_practices).

> _HTML's `<input type="range">` implicitly has the `role` of `slider`. Do not use `aria-valuemax` or `aria-valuemin` attributes on `<input type="range">` elements;

Fixes https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/105