### PR TITLE
Update: Remove ariaQuestion placeholder text (fixes #107)

### DIFF
--- a/example.json
+++ b/example.json
@@ -9,7 +9,7 @@
         "displayTitle": "Confidence Slider",
         "body": "Question text here",
         "instruction": "",
-        "ariaQuestion": "Question text specifically for screen readers.",
+        "ariaQuestion": "",
         "disabledBody": "You need to measure your confidence in the linked part before you can do this part.",
         "_commentAttempts": "Can only be set to 1",
         "_attempts": 1,


### PR DESCRIPTION
Prevent placeholder text being copied over and left in accessible courses. Property description is noted in README and schema help/description for reference.

Fixes https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/107

Missing `ariaQuestion` property added to [wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes/_edit#question-model-attributes).