### PR TITLE
Update: restricts attempts to 1 (fixes #53)

### DIFF
--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -51,6 +51,8 @@
           "title": "Attempts",
           "description": "How many attempts the learner is allowed",
           "default": 1,
+          "minimum": 1,
+          "maximum": 1,
           "properties": {}
         },
         "_shouldDisplayAttempts": {
@@ -459,26 +461,6 @@
                     "translatable": true
                   }
                 }
-              }
-            },
-            "remainingAttemptsText": {
-              "type": "string",
-              "title": "Attempts Remaining Text",
-              "description": "Shown when there are multiple attempts left",
-              "default": "",
-              "properties": {},
-              "_adapt": {
-                "translatable": true
-              }
-            },
-            "remainingAttemptText": {
-              "type": "string",
-              "title": "Final Attempt Text",
-              "description": "Shown when there is one attempt left",
-              "default": "",
-              "properties": {},
-              "_adapt": {
-                "translatable": true
               }
             }
           }


### PR DESCRIPTION
[//]: # Original issue: https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/53 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
* Added "maximum" and "minimum" attributes to restrict the number of "_attempts" to 1 (as described in the README)
* Deleted the property "remainingAttemptsText" because it is not possible for multiple attempts to be left
* Deleted the property "remainingAttemptText" because there is no "final attempt" since only 1 attempt is allowed

