### PR TITLE
Fix: `linkedModel` values not correctly setup on scale when inherited

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ guide the learner’s interaction with the component.
 
 **labelEnd** (string): Text/characters that appear at the end of the slider scale.
 
-**\_scaleStart** (number): This value is the numeric start of the scale. It is used to calculate the slider's position on the scale.
+**\_scaleStart** (number): This value is the numeric start of the scale. It is used to calculate the slider's position on the scale. The default is `1`.
 
-**\_scaleEnd** (number): This value is the numeric end of the scale. It is used to calculate the slider's position on the scale.
+**\_scaleEnd** (number): This value is the numeric end of the scale. It is used to calculate the slider's position on the scale. The default is `10`.
 
-**\_scaleStep** (number): Defines the amount the scale should be incremented by.
+**\_scaleStep** (number): Defines the amount the scale should be incremented by. The default is `1`.
 
 **\_showNumber** (boolean): When set to `true`, a numeric value appears on the marker described in **\_showScaleIndicator**. The value indicates the slider's position on the scale. The default is `true`. Note that **\_showScaleIndicator** must be set to `true` in order for this to work.
 

--- a/js/ConfidenceSliderModel.js
+++ b/js/ConfidenceSliderModel.js
@@ -1,7 +1,8 @@
 import Adapt from 'core/js/adapt';
+import data from 'core/js/data';
+import logging from 'core/js/logging';
 import BUTTON_STATE from 'core/js/enums/buttonStateEnum';
 import SliderModel from 'components/adapt-contrib-slider/js/SliderModel';
-import logging from 'core/js/logging';
 
 export default class ConfidenceSliderModel extends SliderModel {
 
@@ -134,9 +135,9 @@ export default class ConfidenceSliderModel extends SliderModel {
   _setupLinkedModel() {
     const linkedToId = this.get('_linkedToId');
     if (!linkedToId) return;
-    this.linkedModel = Adapt.components.findWhere({ _id: linkedToId });
+    this.linkedModel = data.findById(linkedToId);
     if (!this.linkedModel) {
-      return logging.error('Please check that you have set _linkedToId correctly!');
+      return logging.error(`Could not find \`_linkedToId: ${linkedToId}\` for ${this.get('_id')}`);
     }
     if (this.linkedModel.get('_component') !== 'confidenceSlider') {
       return logging.warn(`The component you have linked confidenceSlider ${this.get('_id')} to is not a confidenceSlider component!`);

--- a/js/ConfidenceSliderModel.js
+++ b/js/ConfidenceSliderModel.js
@@ -9,11 +9,6 @@ export default class ConfidenceSliderModel extends SliderModel {
     super.init();
     if (!this.get('_linkedToId')) return;
     this.set('originalBody', this.get('body'));
-    this.setupEventListeners();
-  }
-
-  setupEventListeners() {
-    this.listenToOnce(Adapt, 'adapt:initialize', this._setupLinkedModel);
   }
 
   /* override */
@@ -25,10 +20,11 @@ export default class ConfidenceSliderModel extends SliderModel {
 
   /* override to indicate that all options are correct */
   setupModelItems() {
+    this._setupLinkedModel();
     const items = [];
-    const start = this.get('_scaleStart') ?? 1;
-    const end = this.get('_scaleEnd') ?? 1;
-    const step = this.get('_scaleStep') || 1;
+    const start = this.get('_scaleStart');
+    const end = this.get('_scaleEnd');
+    const step = this.get('_scaleStep');
     for (let i = start; i <= end; i += step) {
       items.push({
         value: i,
@@ -43,6 +39,11 @@ export default class ConfidenceSliderModel extends SliderModel {
       _items: items,
       _marginDir: (Adapt.config.get('_defaultDirection') === 'rtl' ? 'right' : 'left')
     });
+  }
+
+  onAdaptInitialize() {
+    this.updateFromLinkedModel();
+    super.onAdaptInitialize();
   }
 
   /* override */
@@ -116,6 +117,7 @@ export default class ConfidenceSliderModel extends SliderModel {
   }
 
   updateFromLinkedModel() {
+    if (!this.linkedModel) return;
     const isSubmitted = this.linkedModel.get('_isSubmitted');
     this.set('body', isSubmitted ? this.get('originalBody') : this.get('disabledBody'));
     this.set('_isEnabled', isSubmitted);
@@ -130,7 +132,9 @@ export default class ConfidenceSliderModel extends SliderModel {
   }
 
   _setupLinkedModel() {
-    this.linkedModel = Adapt.components.findWhere({ _id: this.get('_linkedToId') });
+    const linkedToId = this.get('_linkedToId');
+    if (!linkedToId) return;
+    this.linkedModel = Adapt.components.findWhere({ _id: linkedToId });
     if (!this.linkedModel) {
       return logging.error('Please check that you have set _linkedToId correctly!');
     }
@@ -148,7 +152,6 @@ export default class ConfidenceSliderModel extends SliderModel {
       _scaleEnd: this.linkedModel.get('_scaleEnd')
     });
     this._listenToLinkedModel();
-    this.updateFromLinkedModel();
     if (this.get('_attempts') < 0) this.linkedModel.set('_attempts', 1);
   }
 

--- a/properties.schema
+++ b/properties.schema
@@ -185,7 +185,7 @@
     "_scaleEnd": {
       "type": "number",
       "required": true,
-      "default": 1,
+      "default": 10,
       "title": "Scale End",
       "inputType": "Number",
       "validators": ["required", "number"],

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -140,7 +140,7 @@
           "type": "number",
           "title": "Scale End",
           "description": "What number the scale should end on",
-          "default": 1,
+          "default": 10,
           "properties": {}
         },
         "_scaleStep": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -148,6 +148,7 @@
           "title": "Scale Step",
           "description": "The amount the scale should increment by",
           "default": 1,
+          "exclusiveMinimum": 0,
           "properties": {}
         },
         "_correctAnswer": {


### PR DESCRIPTION
Fixes #110.

### Fix
* Amended execution order so `_setupLinkedModel` is called before `setupModelItems` so model values inherited from `linkedModel` are already set in order for `_items` to be correctly configured.
* Restrict `_scaleStep` to a positive number.

### Update
* Changed `_scaleEnd` schema default from 1 to 10.
