### PR TITLE
Chore: Add support for new issue experience (fixes #115)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,23 @@
+---
+name: Issue template
+about: Create an issue to help us improve
+---
+
+### Subject of the issue/enhancement/features
+Describe your issue here.
+
+### Your environment
+* version (AT/Framework)
+* which browser and its version
+* device(s) + operating system(s)
+
+### Steps to reproduce
+Tell us how to reproduce this issue.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Screenshots (if you can)


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-confidenceSlider/issues/115

### Chore
* Add new `issue_template.md` file with YAML frontmatter
* Add new `config.yml` file to disable blank template
